### PR TITLE
Fix failing checklist test

### DIFF
--- a/checklists/tests.py
+++ b/checklists/tests.py
@@ -54,9 +54,13 @@ class ChecklistModelTests(TestCase):
         self.assertEqual(result1.status, ChecklistItemStatus.PENDING)
 
     def test_checklist_run_mark_complete(self):
-        checklist_run = Checklist.objects.create(template=self.template, performed_by=self.user)
+        checklist_run = Checklist.objects.create(
+            template=self.template,
+            performed_by=self.user,
+            status=ChecklistRunStatus.IN_PROGRESS,
+        )
         self.assertFalse(checklist_run.is_complete)
-        self.assertEqual(checklist_run.status, ChecklistRunStatus.IN_PROGRESS) # или DRAFT, в зависимости от дефолта
+        self.assertEqual(checklist_run.status, ChecklistRunStatus.IN_PROGRESS)
 
         checklist_run.mark_complete()
         checklist_run.refresh_from_db()


### PR DESCRIPTION
## Summary
- ensure `test_checklist_run_mark_complete` explicitly creates run in progress

## Testing
- `python3 manage.py test checklists.tests.ChecklistModelTests.test_checklist_run_mark_complete --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_684a78f133f0832e8e27163658b1e67b