### PR TITLE
Fix logic issues and add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -123,3 +123,4 @@ django-simpleui
 qrcode[pil]
 #django-qr-code
 django-phonenumber-field
+phonenumbers

--- a/tasks/admin.py
+++ b/tasks/admin.py
@@ -364,4 +364,5 @@ class TaskCommentAdmin(admin.ModelAdmin):
     def save_model(self, request, obj, form, change):
         setattr(obj, '_initiator_user_id', request.user.id)
         super().save_model(request, obj, form, change)
-        if hasattr(obj, '_initiator_user_id'): delattr(obj, '_initiator_user_id')
+        if hasattr(obj, '_initiator_user_id'):
+            delattr(obj, '_initiator_user_id')

--- a/tasks/filters.py
+++ b/tasks/filters.py
@@ -149,18 +149,35 @@ class TaskFilter(BaseFilter):
         ]
 
     def search_filter(self, queryset, name, value):
-        if not value: return queryset
-        return queryset.filter(
-            Q(task_number__icontains=value) |
-            Q(title__icontains=value) |
-            Q(description__icontains=value)
-        ).distinct()
+        if not value:
+            return queryset
+        return (
+            queryset.filter(
+                Q(task_number__icontains=value)
+                | Q(title__icontains=value)
+                | Q(description__icontains=value)
+            )
+            .distinct()
+        )
 
     def filter_by_assignment_role(self, queryset, name, value):
-         role_to_filter = None
-         if name == 'responsible': role_to_filter = TaskAssignment.RoleChoices.RESPONSIBLE
-         elif name == 'executor': role_to_filter = TaskAssignment.RoleChoices.EXECUTOR
-         elif name == 'watcher': role_to_filter = TaskAssignment.RoleChoices.WATCHER
-         else: logger.warning(f"filter_by_assignment_role called with unexpected filter name: {name}"); return queryset
-         if value and role_to_filter: return queryset.filter(assignments__user=value, assignments__role=role_to_filter).distinct()
-         return queryset
+        role_to_filter = None
+        if name == "responsible":
+            role_to_filter = TaskAssignment.RoleChoices.RESPONSIBLE
+        elif name == "executor":
+            role_to_filter = TaskAssignment.RoleChoices.EXECUTOR
+        elif name == "watcher":
+            role_to_filter = TaskAssignment.RoleChoices.WATCHER
+        else:
+            logger.warning(
+                "filter_by_assignment_role called with unexpected filter name: %s",
+                name,
+            )
+            return queryset
+
+        if value and role_to_filter:
+            return queryset.filter(
+                assignments__user=value,
+                assignments__role=role_to_filter,
+            ).distinct()
+        return queryset

--- a/tasks/serializers.py
+++ b/tasks/serializers.py
@@ -168,13 +168,15 @@ class TaskSerializer(serializers.ModelSerializer):
             for assignment_data in assignments_data:
                 user_obj = assignment_data.get('user')
                 if isinstance(user_obj, int):
-                     user_obj = User.objects.get(pk=user_obj)
+                    user_obj = User.objects.get(pk=user_obj)
 
                 TaskAssignment.objects.create(
                     task=instance, 
                     user=user_obj, 
                     role=assignment_data['role'],
-                    assigned_by=self.context['request'].user if 'request' in self.context else None
+                    assigned_by=(
+                        self.context['request'].user if 'request' in self.context else None
+                    )
                 )
         
         instance.refresh_from_db() # To get updated assignments if needed by response


### PR DESCRIPTION
## Summary
- clean up Celery overdue task logic
- refactor TaskDeleteView and TaskPerformView
- tidy serializer assignments update
- adjust admin save hook
- add `phonenumbers` to requirements
- refine assignment role filter
- fix consumer early returns

## Testing
- `python -m py_compile tasks/consumers.py tasks/filters.py tasks/tasks.py tasks/views/task.py tasks/serializers.py tasks/admin.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6849fa82cc40832e84cf07f5ef486338