### PR TITLE
Fix template list rendering error

### DIFF
--- a/checklists/tests.py
+++ b/checklists/tests.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.utils.translation import gettext_lazy as _
+from .filters import ChecklistTemplateFilter
 from .models import (
     Location,
     ChecklistPoint,

--- a/templates/checklists/template_list.html
+++ b/templates/checklists/template_list.html
@@ -1,5 +1,5 @@
 {% extends 'base.html' %}
-{% load i18n static app_filters %}
+{% load i18n static app_filters widget_tweaks %}
 
 {% block title %}{% trans "Шаблоны чеклистов" %}{% endblock %}
 


### PR DESCRIPTION
## Summary
- load `widget_tweaks` in checklist template list so `render_field` works
- fix failing test module import

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: IntegrityError UNIQUE constraint failed: user_profiles_user.email)*

------
https://chatgpt.com/codex/tasks/task_e_684f025edb90832eae4c0b1870f1367a