### PR TITLE
Fix logging noise for templates

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -234,6 +234,7 @@ LOGGING = {
     },
     "loggers": {
         "django": {"handlers": ["console"], "level": "DEBUG"},
+        "django.template": {"handlers": ["console"], "level": "INFO", "propagate": False},
         "tasks": {"handlers": ["console"], "level": "DEBUG"},
         "checklists": {"handlers": ["console"], "level": "DEBUG"},
     },


### PR DESCRIPTION
## Summary
- tweak logging settings so 'django.template' output isn't at DEBUG

## Testing
- `python manage.py test -v 2` *(fails: UNIQUE constraint failed: user_profiles_user.email)*

------
https://chatgpt.com/codex/tasks/task_e_684f58851ab8832ebedafb777f99029a