### PR TITLE
Add location parent validation tests

### DIFF
--- a/checklists/tests.py
+++ b/checklists/tests.py
@@ -75,6 +75,22 @@ class ChecklistModelTests(TestCase):
                 name="Invalid", parent=room, level=LocationLevel.VENUE
             )
 
+    def test_location_parent_cannot_be_self(self):
+        self.location.parent = self.location
+        with self.assertRaises(ValidationError):
+            self.location.full_clean()
+
+    def test_location_parent_cycle_invalid(self):
+        room = Location.objects.create(
+            name="Hall", parent=self.location, level=LocationLevel.ROOM
+        )
+        corner = Location.objects.create(
+            name="Corner", parent=room, level=LocationLevel.AREA
+        )
+        self.location.parent = corner
+        with self.assertRaises(ValidationError):
+            self.location.full_clean()
+
     def test_checklist_point_creation(self):
         self.assertEqual(ChecklistPoint.objects.count(), 1)
         self.assertEqual(self.point.name, "Room 101")


### PR DESCRIPTION
## Summary
- test self-referential parent location validation
- test cyclic parent location validation

## Testing
- `python manage.py test checklists.tests.ChecklistModelTests.test_location_parent_cannot_be_self checklists.tests.ChecklistModelTests.test_location_parent_cycle_invalid -v 2`

------
https://chatgpt.com/codex/tasks/task_e_684f5ffeef6c832ebad0618e0a31108d