### PR TITLE
Improve mobile layout

### DIFF
--- a/static/js/tasks_no_modal.js
+++ b/static/js/tasks_no_modal.js
@@ -51,6 +51,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // --- Shared Variables & Functions ---
     const taskListContainer = document.getElementById('task-list');
+    const taskCardListContainer = document.getElementById('task-card-list');
     const kanbanBoardContainer = document.getElementById('kanban-board');
     const taskDetailContainer = document.getElementById('task-detail-container');
 
@@ -172,23 +173,31 @@ document.addEventListener('DOMContentLoaded', () => {
                 textEl.textContent = isCurrentlyKanban ? listText : kanbanText;
                 btn.setAttribute('aria-pressed', isCurrentlyKanban.toString());
             };
+            const isDesktop = () => window.matchMedia('(min-width: 768px)').matches;
             const setView = (view) => {
                 const isKanban = view === 'kanban';
-                kanbanBoardContainer.classList.toggle('hidden', !isKanban);
-                taskListContainer.classList.toggle('hidden', isKanban);
-                document.getElementById('pagination')?.classList.toggle('hidden', isKanban || !document.getElementById('pagination'));
-                columnToggleDropdown?.closest('.relative')?.classList.toggle('hidden', !isKanban);
+                const desktop = isDesktop();
+                kanbanBoardContainer.classList.toggle('hidden', !desktop || !isKanban);
+                taskListContainer.classList.toggle('hidden', !desktop || isKanban);
+                taskCardListContainer?.classList.toggle('hidden', desktop);
+                const paginationEl = document.getElementById('pagination');
+                if (paginationEl) {
+                    const showPagination = desktop ? !isKanban : true;
+                    paginationEl.classList.toggle('hidden', !showPagination);
+                }
+                columnToggleDropdown?.closest('.relative')?.classList.toggle('hidden', !isKanban || !desktop);
                 updateButton(toggleViewBtn, document.getElementById('viewIcon'), document.getElementById('viewText'), view);
                 updateButton(toggleViewBtnMobile, document.getElementById('viewIconMobile'), document.getElementById('viewTextMobile'), view);
                 localStorage.setItem('taskView', view);
-                if (isKanban) { initializeKanban(); restoreHiddenColumns(); }
-                else { initializeListSort(); initializeListStatusChange(); initializeListDeleteButtons(); }
+                if (isKanban) { if (desktop) { initializeKanban(); restoreHiddenColumns(); } }
+                else { if (desktop) { initializeListSort(); initializeListStatusChange(); initializeListDeleteButtons(); } }
                 if (window.history.pushState) { const newUrl = new URL(window.location.href); newUrl.searchParams.set('view', view); window.history.pushState({ path: newUrl.href }, '', newUrl.href); }
             };
             setView(initialView);
             [toggleViewBtn, toggleViewBtnMobile].forEach(btn => {
                 if (btn) btn.addEventListener('click', () => setView((localStorage.getItem('taskView') || 'kanban') === 'kanban' ? 'list' : 'kanban'));
             });
+            window.addEventListener('resize', () => setView(localStorage.getItem('taskView') || 'kanban'));
         }
 
         let sortableInstances = [];

--- a/templates/includes/kanban_board.html
+++ b/templates/includes/kanban_board.html
@@ -1,7 +1,7 @@
 {% load static i18n app_filters %}
 
 <div id="kanban-board"
-    class="mt-6 flex flex-nowrap overflow-x-auto gap-4 pb-4 -mx-4 px-4 scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent hidden">
+    class="mt-6 flex flex-nowrap overflow-x-auto gap-4 pb-4 -mx-4 px-4 scrollbar-thin scrollbar-thumb-gray-300 scrollbar-track-transparent hidden md:flex">
     {% for status_code, task_list in tasks_by_status.items %}
     {% with status_display_name=status_mapping_dict|get_item:status_code %}
     <div class="kanban-column-wrapper flex-shrink-0 w-72 md:w-80" data-status="{{ status_code }}">

--- a/templates/includes/task_card_list.html
+++ b/templates/includes/task_card_list.html
@@ -1,0 +1,51 @@
+{% load static i18n app_filters %}
+<div id="task-card-list" class="space-y-4 md:hidden">
+    {% for task in tasks_for_cards %}
+    {% with priority_border_class=task.priority|get_priority_border_color priority_text_class=task.priority|get_priority_text_color responsible_user=task.get_responsible_users.first %}
+    <div class="bg-white rounded-lg shadow border-l-4 {{ priority_border_class }} p-4 flex flex-col">
+        <div class="flex justify-between items-center text-xs mb-2">
+            <a href="{% url 'tasks:task_detail' pk=task.pk %}" class="font-mono font-medium text-blue-600 bg-blue-50 px-2 py-0.5 rounded-full hover:bg-blue-100">#{{ task.task_number|default:task.pk }}</a>
+            {% if task.project %}
+            <a href="{{ task.project.get_absolute_url }}" class="text-gray-500 hover:underline truncate ml-2 hover:text-gray-700"><i class="fas fa-project-diagram fa-fw mr-1 opacity-70"></i>{{ task.project.name|truncatechars:20 }}</a>
+            {% endif %}
+        </div>
+        <a href="{% url 'tasks:task_detail' pk=task.pk %}" class="block mb-2">
+            <p class="text-sm font-medium text-gray-800 break-words">{{ task.title }}</p>
+        </a>
+        <div class="space-y-1.5 text-xs text-gray-600 mb-3">
+            <div class="flex items-center gap-1.5">
+                <i class="fas fa-user-plus fa-fw text-gray-400"></i>
+                {% if task.created_by %}
+                    {{ task.created_by.display_name|default:task.created_by.username }}
+                {% else %}<span>-</span>{% endif %}
+                <span class="text-gray-400 ml-auto"><i class="far fa-calendar-plus fa-fw mr-1"></i>{{ task.created_at|date:"d.m.y" }}</span>
+            </div>
+            {% if responsible_user %}
+            <div class="flex items-center gap-1.5">
+                <i class="fas fa-user-check fa-fw text-gray-400"></i>
+                {{ responsible_user.display_name|default:responsible_user.username }}
+            </div>
+            {% else %}
+            <div class="flex items-center gap-1.5 text-gray-400 italic">
+                <i class="fas fa-user-times fa-fw"></i><span>{% trans 'Не назначен' %}</span>
+            </div>
+            {% endif %}
+        </div>
+        <div class="flex items-center justify-between text-xs text-gray-500 mt-auto pt-2 border-t border-gray-100">
+            <span class="inline-flex items-center gap-1.5 font-medium {{ priority_text_class }}" title="{% trans 'Приоритет' %}: {{ task.get_priority_display }}">
+                {% if task.priority == task.TaskPriority.HIGH %}<i class="fas fa-flag fa-fw text-red-500"></i>{% elif task.priority == task.TaskPriority.MEDIUM_HIGH %}<i class="fas fa-angle-double-up fa-fw text-orange-500"></i>{% elif task.priority == task.TaskPriority.MEDIUM %}<i class="fas fa-equals fa-fw text-yellow-500"></i>{% elif task.priority == task.TaskPriority.MEDIUM_LOW %}<i class="fas fa-angle-double-down fa-fw text-blue-500"></i>{% elif task.priority == task.TaskPriority.LOW %}<i class="fas fa-angle-down fa-fw text-green-500"></i>{% else %}<i class="fas fa-question-circle fa-fw text-gray-400"></i>{% endif %}
+                <span class="hidden sm:inline">{{ task.get_priority_display }}</span>
+            </span>
+            {% if task.due_date %}
+            <span class="inline-flex items-center gap-1 {% if task.is_overdue %}text-red-600 font-semibold{% else %}text-gray-500{% endif %}"><i class="far fa-calendar-alt fa-fw"></i>{{ task.due_date|date:"d.m.y" }}</span>
+            {% endif %}
+        </div>
+    </div>
+    {% endwith %}
+    {% empty %}
+    <div class="text-center text-gray-500 text-lg py-12 italic bg-white rounded-xl shadow">
+        <i class="fas fa-folder-open fa-3x mb-3 text-gray-400"></i><br>
+        {% trans 'Задачи не найдены.' %}
+    </div>
+    {% endfor %}
+</div>

--- a/templates/includes/task_list_table.html
+++ b/templates/includes/task_list_table.html
@@ -1,7 +1,7 @@
 {% load i18n app_filters static %}
 
 <div id="task-list"
-    class="mt-6 overflow-x-auto bg-white shadow-lg rounded-xl border border-gray-200 hidden">
+    class="mt-6 overflow-x-auto bg-white shadow-lg rounded-xl border border-gray-200 hidden md:block">
     <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50 sticky top-0 z-10">
             <tr class="text-xs text-left text-gray-500 uppercase tracking-wider">

--- a/templates/tasks/category_list.html
+++ b/templates/tasks/category_list.html
@@ -25,7 +25,26 @@
 {% endblock %}
 
 {% block list_content %}
-<div class="mt-6 overflow-x-auto bg-white shadow-lg rounded-xl border border-gray-200">
+<div class="md:hidden space-y-4 mt-6">
+    {% for category in object_list %}
+    <div class="bg-white shadow rounded-lg p-4 border border-gray-200">
+        <div class="flex justify-between items-center">
+            <a href="{{ category.get_absolute_url }}" class="font-semibold text-blue-600 hover:underline">{{ category.name }}</a>
+            <div class="flex space-x-2">
+                <a href="{% url 'tasks:category_update' pk=category.pk %}" class="p-1.5 rounded-full text-gray-600 hover:bg-gray-100"><i class="fas fa-edit fa-fw"></i></a>
+                <a href="{% url 'tasks:category_delete' pk=category.pk %}" class="p-1.5 rounded-full text-red-600 hover:bg-red-100"><i class="fas fa-trash fa-fw"></i></a>
+            </div>
+        </div>
+        <p class="text-sm text-gray-600 mt-2">{{ category.description|truncatechars:80|default:"-" }}</p>
+        <p class="text-xs text-gray-500 mt-1">{% trans 'Задач' %}: {{ category.tasks.count }}</p>
+    </div>
+    {% empty %}
+    <div class="text-center text-gray-400 italic py-10">
+        <i class="fas fa-folder-open fa-3x mb-3"></i><br>{% trans 'Категории не найдены.' %}
+    </div>
+    {% endfor %}
+</div>
+<div class="mt-6 overflow-x-auto bg-white shadow-lg rounded-xl border border-gray-200 hidden md:block">
     <table class="min-w-full divide-y divide-gray-200">
         <thead class="bg-gray-50">
             <tr class="text-xs text-left text-gray-500 uppercase tracking-wider">

--- a/templates/tasks/project_list.html
+++ b/templates/tasks/project_list.html
@@ -24,37 +24,57 @@
 {% endblock %}
 
 {% block list_content %}
-<div class="mt-4 table-responsive">
-    <table class="table table-striped">
-        <thead>
-            <tr class="text-muted">
-                <th scope="col"><i class="fas fa-project-diagram me-1" aria-hidden="true"></i>{% trans 'Название проекта' %}</th>
-                <th scope="col"><i class="far fa-calendar-alt me-1" aria-hidden="true"></i>{% trans 'Дата начала' %}</th>
-                <th scope="col"><i class="fas fa-calendar-check me-1" aria-hidden="true"></i>{% trans 'Дата завершения' %}</th>
-                <th scope="col" class="text-center"><i class="fas fa-tasks me-1" aria-hidden="true"></i>{% trans 'Задач' %}</th>
-                <th scope="col" class="text-center"><i class="fas fa-cogs me-1" aria-hidden="true"></i>{% trans 'Действия' %}</th>
+<div class="md:hidden space-y-4 mt-6">
+    {% for project in object_list %}
+    <div class="bg-white shadow rounded-lg p-4 border border-gray-200">
+        <div class="flex justify-between items-center">
+            <a href="{{ project.get_absolute_url }}" class="font-semibold text-blue-600 hover:underline">{{ project.name }}</a>
+            <div class="flex space-x-2">
+                <a href="{% url 'tasks:project_update' pk=project.pk %}" class="p-1.5 rounded-full text-gray-600 hover:bg-gray-100"><i class="fas fa-edit fa-fw"></i></a>
+                <a href="{% url 'tasks:project_delete' pk=project.pk %}" class="p-1.5 rounded-full text-red-600 hover:bg-red-100"><i class="fas fa-trash fa-fw"></i></a>
+            </div>
+        </div>
+        <p class="text-sm text-gray-600 mt-2">{% trans 'Дата начала' %}: {{ project.start_date|date:"d.m.Y"|default:"-" }}</p>
+        <p class="text-sm text-gray-600">{% trans 'Дата завершения' %}: {{ project.end_date|date:"d.m.Y"|default:"-" }}</p>
+        <p class="text-xs text-gray-500 mt-1">{% trans 'Задач' %}: {{ project.tasks.count }}</p>
+        <a href="{{ project.get_absolute_url }}" class="text-sm text-indigo-600 hover:underline mt-2 inline-block"><i class="fas fa-eye mr-1"></i>{% trans 'Просмотреть задачи' %}</a>
+    </div>
+    {% empty %}
+    <div class="text-center text-gray-400 italic py-10">
+        <i class="fas fa-folder-open fa-3x mb-3"></i><br>{% trans 'Проекты не найдены.' %}
+    </div>
+    {% endfor %}
+</div>
+<div class="mt-4 overflow-x-auto hidden md:block">
+    <table class="min-w-full divide-y divide-gray-200">
+        <thead class="bg-gray-50">
+            <tr class="text-xs text-left text-gray-500 uppercase tracking-wider">
+                <th scope="col" class="px-4 py-3.5"><i class="fas fa-project-diagram fa-fw mr-1"></i>{% trans 'Название проекта' %}</th>
+                <th scope="col" class="px-4 py-3.5"><i class="far fa-calendar-alt fa-fw mr-1"></i>{% trans 'Дата начала' %}</th>
+                <th scope="col" class="px-4 py-3.5"><i class="fas fa-calendar-check fa-fw mr-1"></i>{% trans 'Дата завершения' %}</th>
+                <th scope="col" class="px-4 py-3.5 text-center"><i class="fas fa-tasks fa-fw mr-1"></i>{% trans 'Задач' %}</th>
+                <th scope="col" class="px-4 py-3.5 text-center"><i class="fas fa-cogs fa-fw mr-1"></i>{% trans 'Действия' %}</th>
             </tr>
         </thead>
-        <tbody>
+        <tbody class="divide-y divide-gray-200">
             {% for project in object_list %}
-            <tr id="project-row-{{ project.pk }}" class="align-middle">
-                <td class="fw-medium"><a href="{{ project.get_absolute_url }}" class="link-primary">{{ project.name }}</a></td>
-                <td>{{ project.start_date|date:"d.m.Y"|default:"-" }}</td>
-                <td>{{ project.end_date|date:"d.m.Y"|default:"-" }}</td>
-                <td class="text-center">{{ project.tasks.count }}</td>
-                <td class="text-center">
-                    <div class="btn-group" role="group">
-                        <a href="{{ project.get_absolute_url }}" title="{% trans 'Просмотреть задачи' %}" class="btn btn-sm btn-outline-primary"><i class="fas fa-eye" aria-hidden="true"></i></a>
-                        <a href="{% url 'tasks:project_update' pk=project.pk %}" title="{% trans 'Редактировать' %}" class="btn btn-sm btn-outline-secondary"><i class="fas fa-edit" aria-hidden="true"></i></a>
-                        <a href="{% url 'tasks:project_delete' pk=project.pk %}" title="{% trans 'Удалить' %}" class="btn btn-sm btn-outline-danger"><i class="fas fa-trash" aria-hidden="true"></i></a>
+            <tr id="project-row-{{ project.pk }}" class="text-sm text-gray-700 hover:bg-gray-50">
+                <td class="px-4 py-3 font-medium"><a href="{{ project.get_absolute_url }}" class="text-blue-600 hover:underline">{{ project.name }}</a></td>
+                <td class="px-4 py-3">{{ project.start_date|date:"d.m.Y"|default:"-" }}</td>
+                <td class="px-4 py-3">{{ project.end_date|date:"d.m.Y"|default:"-" }}</td>
+                <td class="px-4 py-3 text-center">{{ project.tasks.count }}</td>
+                <td class="px-4 py-3 text-center">
+                    <div class="flex items-center justify-center space-x-1">
+                        <a href="{{ project.get_absolute_url }}" title="{% trans 'Просмотреть задачи' %}" class="p-1.5 rounded-full text-blue-600 hover:bg-blue-100"><i class="fas fa-eye fa-fw"></i></a>
+                        <a href="{% url 'tasks:project_update' pk=project.pk %}" title="{% trans 'Редактировать' %}" class="p-1.5 rounded-full text-gray-600 hover:bg-gray-100"><i class="fas fa-edit fa-fw"></i></a>
+                        <a href="{% url 'tasks:project_delete' pk=project.pk %}" title="{% trans 'Удалить' %}" class="p-1.5 rounded-full text-red-600 hover:bg-red-100"><i class="fas fa-trash fa-fw"></i></a>
                     </div>
                 </td>
             </tr>
             {% empty %}
             <tr>
-                <td colspan="5" class="py-5 text-center text-muted">
-                    <i class="fas fa-folder-open fa-3x mb-3 text-secondary" aria-hidden="true"></i><br>
-                    {% trans 'Проекты не найдены.' %}
+                <td colspan="5" class="px-6 py-12 text-center text-gray-400 italic">
+                    <i class="fas fa-folder-open fa-3x mb-3"></i><br>{% trans 'Проекты не найдены.' %}
                 </td>
             </tr>
             {% endfor %}

--- a/templates/tasks/task_list.html
+++ b/templates/tasks/task_list.html
@@ -67,6 +67,7 @@
 
 {% block list_content %}
 {% include 'includes/kanban_board.html' with tasks_by_status=tasks_by_status_kanban status_mapping_dict=status_mapping_dict %}
+{% include 'includes/task_card_list.html' with tasks_for_cards=tasks_page_obj %}
 {% include 'includes/task_list_table.html' with tasks_for_table=tasks_page_obj status_choices_list=status_choices_list current_sort=current_sort request=request %}
 
 {% if is_paginated %}


### PR DESCRIPTION
## Summary
- add Tailwind card view for tasks on mobile
- hide kanban and table on small screens
- tweak view switcher to respect device width
- provide mobile card lists for categories and projects

## Testing
- `python manage.py test` *(fails: Conflicting migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68501afceb34832e8b6f017d4f50cacf