### PR TITLE
Add deployment scripts for Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,24 @@ python manage.py migrate room 0002 --fake
 ```
 
 Repeat for any other app showing the same error, then run `python manage.py migrate` again.
+
+## Deployment on Ubuntu 24.04
+
+Below is a minimal example of how to run the project using Gunicorn and Nginx on a clean Ubuntu 24.04 server. Paths and domain names can be adjusted to your needs.
+
+1. Execute the setup script:
+
+```bash
+bash deploy/ubuntu24/setup.sh
+```
+
+2. Place your environment variables in `/opt/sphinx/.env`.
+3. After the script finishes, Gunicorn will run as a systemd service and Nginx will proxy requests to it.
+
+Configuration files are located under `deploy/ubuntu24/`:
+
+- `gunicorn.service` — systemd unit for the application.
+- `nginx.conf` — sample Nginx site configuration.
+
+The script installs dependencies, creates a virtual environment, applies migrations, collects static files and starts all services.
+

--- a/deploy/ubuntu24/gunicorn.service
+++ b/deploy/ubuntu24/gunicorn.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=gunicorn daemon for Sphinx
+After=network.target
+
+[Service]
+User=www-data
+Group=www-data
+WorkingDirectory=/opt/sphinx
+EnvironmentFile=/opt/sphinx/.env
+ExecStart=/opt/sphinx/venv/bin/gunicorn \
+    --workers 3 \
+    --bind unix:/run/gunicorn.sock \
+    config.wsgi:application
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/ubuntu24/nginx.conf
+++ b/deploy/ubuntu24/nginx.conf
@@ -1,0 +1,20 @@
+server {
+    listen 80;
+    server_name example.com;
+
+    location /static/ {
+        alias /opt/sphinx/staticfiles/;
+    }
+
+    location /media/ {
+        alias /opt/sphinx/media/;
+    }
+
+    location / {
+        proxy_pass http://unix:/run/gunicorn.sock;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/deploy/ubuntu24/setup.sh
+++ b/deploy/ubuntu24/setup.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# Update system and install packages
+sudo apt update
+sudo apt install -y python3.11 python3.11-venv python3.11-dev build-essential libpq-dev nginx git
+
+# Create project directory
+sudo mkdir -p /opt/sphinx
+sudo rsync -a --exclude 'deploy' ./ /opt/sphinx/
+
+cd /opt/sphinx
+python3.11 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# Collect static files and apply migrations
+python manage.py migrate
+python manage.py collectstatic --noinput
+
+sudo cp deploy/ubuntu24/gunicorn.service /etc/systemd/system/gunicorn.service
+sudo systemctl daemon-reload
+sudo systemctl enable gunicorn
+sudo systemctl start gunicorn
+
+sudo cp deploy/ubuntu24/nginx.conf /etc/nginx/sites-available/sphinx.conf
+sudo ln -sf /etc/nginx/sites-available/sphinx.conf /etc/nginx/sites-enabled/
+
+sudo systemctl restart nginx


### PR DESCRIPTION
## Summary
- add `deploy/ubuntu24` folder with systemd and nginx configs
- provide setup script for Ubuntu 24.04
- document deployment instructions in README

## Testing
- `pip install -r requirements.txt`
- `python manage.py test` *(fails: Conflicting migrations detected)*

------
https://chatgpt.com/codex/tasks/task_e_6850bce686fc832eac91ac0c706c3122