### PR TITLE
Fix TaskConsumer disconnect when unauthenticated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ build/
 .env
 .env.*
 .venv/
+venv/
 local_settings.py
 # media/
 # staticfiles/

--- a/tasks/consumers.py
+++ b/tasks/consumers.py
@@ -19,12 +19,13 @@ class TaskConsumer(AsyncWebsocketConsumer):
 
     async def connect(self):
         self.user = self.scope.get('user')
+        # Инициализируем список групп заранее, чтобы disconnect работал корректно
+        self.subscribed_groups = set()
         if not self.user or not self.user.is_authenticated:
             await self.close()
             return
 
         self.task_id_str = self.scope['url_route']['kwargs'].get('task_id')
-        self.subscribed_groups = set()
 
         # Всегда подписываемся на общий список задач
         await self.channel_layer.group_add(self.DEFAULT_GROUP_NAME_LIST, self.channel_name)


### PR DESCRIPTION
## Summary
- initialize `subscribed_groups` before early returns to avoid `AttributeError`
- ignore `venv/` directory

## Testing
- `bash setup_codex.sh`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685157d5bfc8832eadd65316f4fb7db8