### PR TITLE
Fix Browser Reload path

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -23,10 +23,12 @@ schema_view = get_schema_view(
 )
 
 
-urlpatterns = i18n_patterns(
-    path('', include('user_profiles.urls')),
-
+urlpatterns = [
     path("__reload__/", include("django_browser_reload.urls")),
+]
+
+urlpatterns += i18n_patterns(
+    path('', include('user_profiles.urls')),
 
     # Панель администратора
     path("admin/", admin.site.urls),


### PR DESCRIPTION
## Summary
- ensure `django_browser_reload` path isn't localized

## Testing
- `pytest -q`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68515ab588f4832e990de3fb54f9a325