### PR TITLE
Add user group management and subcategory fixes

### DIFF
--- a/tasks/models.py
+++ b/tasks/models.py
@@ -262,6 +262,18 @@ class Task(BaseModel):
            self.status not in [self.StatusChoices.COMPLETED, self.StatusChoices.CANCELLED, self.StatusChoices.OVERDUE]:
             self.status = self.StatusChoices.OVERDUE
 
+        if self._state.adding and not self.due_date:
+            start = self.start_date or timezone.now().date()
+            priority_map = {
+                self.TaskPriority.HIGH: timedelta(days=1),
+                self.TaskPriority.MEDIUM_HIGH: timedelta(days=3),
+                self.TaskPriority.MEDIUM: timedelta(days=7),
+                self.TaskPriority.MEDIUM_LOW: timedelta(days=14),
+                self.TaskPriority.LOW: timedelta(days=30),
+            }
+            delta = priority_map.get(self.priority, timedelta(days=7))
+            self.due_date = start + delta
+
     def save(self, *args, **kwargs):
         is_new = self._state.adding
         if not kwargs.pop('skip_clean', False): self.full_clean()

--- a/tasks/tests.py
+++ b/tasks/tests.py
@@ -43,3 +43,15 @@ class TaskChatIntegrationTests(TestCase):
         response = self.client.get(reverse('room:room', kwargs={'slug': task_room.slug}))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context['related_task'], task)
+
+
+class TaskDueDateTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='dueuser', password='pass')
+        self.project = Project.objects.create(name='DD Project', owner=self.user)
+
+    def test_due_date_auto_set_high_priority(self):
+        task = Task.objects.create(project=self.project, title='HP', created_by=self.user,
+                                   priority=Task.TaskPriority.HIGH)
+        self.assertIsNotNone(task.due_date)
+        self.assertEqual((task.due_date - task.start_date).days, 1)

--- a/tasks/views/api.py
+++ b/tasks/views/api.py
@@ -65,14 +65,17 @@ class TaskSubcategoryViewSet(viewsets.ModelViewSet):
         
         page = self.paginate_queryset(queryset)
         if page is not None:
-            serializer = self.get_serializer(page, many=True)
             if request.accepted_renderer.format == 'json' and request.query_params.get('select2'):
-                 return Response(serializer.data)
+                data = [{'id': sc.id, 'text': f"{sc.category.name} / {sc.name}"} for sc in page]
+                return Response(data)
+            serializer = self.get_serializer(page, many=True)
             return self.get_paginated_response(serializer.data)
 
-        serializer = self.get_serializer(queryset, many=True)
         if request.accepted_renderer.format == 'json' and request.query_params.get('select2'):
-             return Response(serializer.data)
+            data = [{'id': sc.id, 'text': f"{sc.category.name} / {sc.name}"} for sc in queryset]
+            return Response(data)
+
+        serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
 

--- a/templates/users/group_confirm_delete.html
+++ b/templates/users/group_confirm_delete.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{{ page_title|default:_('Удаление группы') }}{% endblock %}
+
+{% block list_title %}
+<h1 class="text-2xl font-semibold text-gray-900 sm:text-3xl">{{ page_title|default:_('Удаление группы') }}</h1>
+{% endblock %}
+
+{% block list_content %}
+<div class="bg-white shadow-lg rounded-xl border border-gray-200 p-6 md:p-8 mt-6 max-w-lg mx-auto">
+    <p class="text-gray-700 mb-4">{% blocktrans with name=object.name %}Вы уверены, что хотите удалить группу <strong>{{ name }}</strong>?{% endblocktrans %}</p>
+    <p class="text-red-600 font-semibold mb-6">{% trans 'Это действие нельзя будет отменить!' %}</p>
+    <form method="post" action="">
+        {% csrf_token %}
+        <div class="flex justify-end space-x-3">
+            <a href="{% url 'user_profiles:group_list' %}" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">{% trans 'Отмена' %}</a>
+            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition active:scale-95 shadow-sm">
+                <i class="fas fa-trash mr-2"></i> {% trans 'Да, удалить группу' %}
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/users/group_detail.html
+++ b/templates/users/group_detail.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{% blocktrans with name=object.name %}Группа: {{ name }}{% endblocktrans %}{% endblock %}
+
+{% block list_title %}
+<h1 class="text-2xl font-semibold text-gray-900 sm:text-3xl">{% blocktrans with name=object.name %}Группа: {{ name }}{% endblocktrans %}</h1>
+{% endblock %}
+
+{% block list_content %}
+<div class="bg-white shadow rounded-xl border border-gray-200 p-6 md:p-8 mt-6 max-w-2xl mx-auto">
+    <p class="mb-4"><strong>{% trans 'Название' %}:</strong> {{ object.name }}</p>
+    <p class="mb-4"><strong>{% trans 'Пользователей' %}:</strong> {{ object.user_set.count }}</p>
+    <div class="mb-4">
+        <strong>{% trans 'Разрешения' %}:</strong>
+        <ul class="list-disc list-inside ml-4">
+        {% for perm in object.permissions.all %}
+            <li>{{ perm.name }}</li>
+        {% empty %}
+            <li class="text-gray-500">{% trans 'Нет' %}</li>
+        {% endfor %}
+        </ul>
+    </div>
+    <div class="flex justify-end gap-3 pt-4 border-t border-gray-200">
+        <a href="{% url 'user_profiles:group_update' pk=object.pk %}" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">{% trans 'Изменить' %}</a>
+        <a href="{% url 'user_profiles:group_delete' pk=object.pk %}" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition active:scale-95 shadow-sm">{% trans 'Удалить' %}</a>
+    </div>
+</div>
+{% endblock %}

--- a/templates/users/group_form.html
+++ b/templates/users/group_form.html
@@ -1,0 +1,29 @@
+{% extends 'base.html' %}
+{% load i18n crispy_forms_tags %}
+
+{% block title %}{{ page_title }}{% endblock %}
+
+{% block list_title %}
+  <h1 class="text-2xl font-semibold text-gray-900 sm:text-3xl">{{ page_title }}</h1>
+{% endblock %}
+
+{% block list_content %}
+<div class="bg-white shadow-xl rounded-xl border border-gray-200 p-6 md:p-8 mt-6 max-w-2xl mx-auto">
+    <form method="post" action="">
+        {% csrf_token %}
+        {% crispy form %}
+        {% if form.non_field_errors %}
+            <div role="alert" class="mt-4 p-4 border border-red-400 bg-red-100 text-red-700 rounded-md">
+                <h4 class="font-bold mb-1">{% trans "Ошибка формы:" %}</h4>
+                {% for error in form.non_field_errors %}<p class="text-sm">{{ error }}</p>{% endfor %}
+            </div>
+        {% endif %}
+        <div class="flex justify-end gap-3 mt-6 pt-6 border-t border-gray-200">
+            <a href="{% url 'user_profiles:group_list' %}" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">{% trans 'Отмена' %}</a>
+            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center">
+                <i class="fas fa-save mr-2"></i> {{ form_action_text|default:_('Сохранить') }}
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/templates/users/group_list.html
+++ b/templates/users/group_list.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{{ page_title|default:_('Группы прав') }}{% endblock %}
+
+{% block list_title %}
+  <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+    <h1 class="text-2xl font-semibold text-gray-900 sm:text-3xl">{{ page_title|default:_('Группы прав') }}</h1>
+    {% if perms.auth.add_group %}
+    <nav>
+      <a href="{% url 'user_profiles:group_create' %}" class="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-center font-medium text-white hover:bg-blue-700 lg:px-6 transition active:scale-95 shadow-sm">
+        <i class="fas fa-plus mr-2"></i> {% trans 'Создать группу' %}
+      </a>
+    </nav>
+    {% endif %}
+  </div>
+{% endblock %}
+
+{% block list_content %}
+  <div class="bg-white shadow rounded-xl border border-gray-200">
+    <table class="min-w-full divide-y divide-gray-200">
+      <thead class="bg-gray-50">
+        <tr>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{% trans 'Название' %}</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{% trans 'Пользователей' %}</th>
+          <th class="px-6 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="bg-white divide-y divide-gray-200">
+        {% for group in object_list %}
+        <tr>
+          <td class="px-6 py-4 whitespace-nowrap">{{ group.name }}</td>
+          <td class="px-6 py-4 whitespace-nowrap">{{ group.num_users }}</td>
+          <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+            <a href="{% url 'user_profiles:group_update' pk=group.pk %}" class="text-indigo-600 hover:text-indigo-900 mr-3">{% trans 'Изменить' %}</a>
+            <a href="{% url 'user_profiles:group_delete' pk=group.pk %}" class="text-red-600 hover:text-red-900">{% trans 'Удалить' %}</a>
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td colspan="3" class="px-6 py-4 text-center text-gray-500">{% trans 'Группы не найдены.' %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% if is_paginated %}
+    <div class="px-6 py-4">{% include 'includes/pagination.html' with page_obj=page_obj %}</div>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/user_profiles/forms.py
+++ b/user_profiles/forms.py
@@ -3,7 +3,7 @@ import logging
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Row, Field, Div, Column
 from django import forms
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import Group, Permission
 from django.contrib.auth.forms import (
     AuthenticationForm, UserCreationForm as BaseUserCreationForm, PasswordChangeForm as BasePasswordChangeForm
 )
@@ -139,6 +139,36 @@ class JobTitleForm(forms.ModelForm):
         self.helper.layout = Layout(
             Field('name', css_class="mb-4"),
             Field('description', css_class="mb-4"),
+        )
+
+
+class GroupForm(forms.ModelForm):
+    permissions = forms.ModelMultipleChoiceField(
+        queryset=Permission.objects.all().order_by('content_type__app_label', 'codename'),
+        required=False,
+        widget=Select2MultipleWidget(attrs={'data-placeholder': _("Выберите разрешения...")}),
+        label=_("Разрешения")
+    )
+
+    class Meta:
+        model = Group
+        fields = ["name", "permissions"]
+        widgets = {
+            'name': forms.TextInput(attrs={'class': TEXT_INPUT_CLASSES, 'placeholder': _("Название группы")}),
+        }
+        labels = {
+            'name': _("Название группы"),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.helper = FormHelper(self)
+        self.helper.form_method = 'post'
+        self.helper.form_tag = False
+        self.helper.disable_csrf = True
+        self.helper.layout = Layout(
+            Field('name', css_class="mb-4"),
+            Field('permissions', css_class="mb-4"),
         )
 
 

--- a/user_profiles/urls.py
+++ b/user_profiles/urls.py
@@ -47,4 +47,10 @@ urlpatterns = [
     path('manage/jobtitles/create/', views.JobTitleCreateView.as_view(), name='jobtitle_create'),
     path('manage/jobtitles/<int:pk>/update/', views.JobTitleUpdateView.as_view(), name='jobtitle_update'),
     path('manage/jobtitles/<int:pk>/delete/', views.JobTitleDeleteView.as_view(), name='jobtitle_delete'),
+
+    path('manage/groups/', views.GroupListView.as_view(), name='group_list'),
+    path('manage/groups/create/', views.GroupCreateView.as_view(), name='group_create'),
+    path('manage/groups/<int:pk>/', views.GroupDetailView.as_view(), name='group_detail'),
+    path('manage/groups/<int:pk>/update/', views.GroupUpdateView.as_view(), name='group_update'),
+    path('manage/groups/<int:pk>/delete/', views.GroupDeleteView.as_view(), name='group_delete'),
 ]


### PR DESCRIPTION
## Summary
- add GroupForm and CRUD views for permission groups
- create templates for group management UI
- improve API response for task subcategory Select2
- set task due date based on priority
- test automatic due dates

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_6853f82c9fd8832ea90c397eee28a83b