### PR TITLE
Add dashboards app with task analytics

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "widget_tweaks",
     'phonenumber_field',
     "taggit",
+    "dashboards",
 ]
 
 MIDDLEWARE = [

--- a/config/urls.py
+++ b/config/urls.py
@@ -43,6 +43,7 @@ urlpatterns = i18n_patterns(
     path('checklists/', include('checklists.urls', namespace='checklists')),
     path('qr-feedback/', include('qrfikr.urls', namespace='qrfikr')),
     path('reviews/', include('reviews.urls')),
+    path('dashboards/', include('dashboards.urls', namespace='dashboards')),
     # path('hrbot/', include('hrbot.urls', namespace='hrbot')),
     path('select2/', include('django_select2.urls')),
     # Swagger UI

--- a/dashboards/apps.py
+++ b/dashboards/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DashboardsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'dashboards'

--- a/dashboards/tests.py
+++ b/dashboards/tests.py
@@ -1,0 +1,15 @@
+from django.urls import reverse
+from rest_framework.test import APITestCase
+from django.contrib.auth import get_user_model
+
+
+class DashboardViewTests(APITestCase):
+    def setUp(self):
+        self.user = get_user_model().objects.create_user(username='dash', password='pass')
+        self.client.login(username='dash', password='pass')
+
+    def test_dashboard_view(self):
+        url = reverse('dashboards:task_dashboard')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn('Дашборд задач', response.content.decode())

--- a/dashboards/urls.py
+++ b/dashboards/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import views
+
+app_name = 'dashboards'
+
+urlpatterns = [
+    path('tasks/', views.TaskDashboardView.as_view(), name='task_dashboard'),
+]

--- a/dashboards/views.py
+++ b/dashboards/views.py
@@ -1,0 +1,110 @@
+import json
+from datetime import datetime
+from django.db.models import Count
+from django.db.models.functions import TruncMonth
+from django.views.generic import TemplateView
+from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
+
+from tasks.models import Task, TaskCategory, TaskSubcategory, Department
+
+User = get_user_model()
+
+
+class TaskDashboardView(TemplateView):
+    template_name = 'dashboards/task_dashboard.html'
+
+    def get_filter_queryset(self):
+        qs = Task.objects.all()
+        start_date = self.request.GET.get('start')
+        end_date = self.request.GET.get('end')
+        user = self.request.GET.get('user')
+        category = self.request.GET.get('category')
+        subcategory = self.request.GET.get('subcategory')
+        department = self.request.GET.get('department')
+        if start_date:
+            try:
+                start = datetime.fromisoformat(start_date).date()
+                qs = qs.filter(start_date__gte=start)
+            except ValueError:
+                pass
+        if end_date:
+            try:
+                end = datetime.fromisoformat(end_date).date()
+                qs = qs.filter(due_date__lte=end)
+            except ValueError:
+                pass
+        if user:
+            qs = qs.filter(assignments__user_id=user)
+        if category:
+            qs = qs.filter(category_id=category)
+        if subcategory:
+            qs = qs.filter(subcategory_id=subcategory)
+        if department:
+            qs = qs.filter(department_id=department)
+        return qs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        qs = self.get_filter_queryset()
+
+        status_data = list(
+            qs.values('status').annotate(total=Count('id')).order_by('status')
+        )
+        status_labels = [_(dict(Task.StatusChoices.choices).get(d['status'], d['status'])) for d in status_data]
+        status_values = [d['total'] for d in status_data]
+
+        user_data = list(
+            qs.values('assignments__user__username')
+            .annotate(total=Count('id'))
+            .order_by('-total')[:10]
+        )
+        user_labels = [d['assignments__user__username'] or _('None') for d in user_data]
+        user_values = [d['total'] for d in user_data]
+
+        cat_data = list(
+            qs.values('category__name').annotate(total=Count('id')).order_by('-total')[:10]
+        )
+        cat_labels = [d['category__name'] or _('None') for d in cat_data]
+        cat_values = [d['total'] for d in cat_data]
+
+        subcat_data = list(
+            qs.values('subcategory__name').annotate(total=Count('id')).order_by('-total')[:10]
+        )
+        subcat_labels = [d['subcategory__name'] or _('None') for d in subcat_data]
+        subcat_values = [d['total'] for d in subcat_data]
+
+        month_data = list(
+            qs.annotate(month=TruncMonth('due_date'))
+            .values('month')
+            .annotate(total=Count('id'))
+            .order_by('month')
+        )
+        month_labels = [d['month'].strftime('%Y-%m') if d['month'] else _('None') for d in month_data]
+        month_values = [d['total'] for d in month_data]
+
+        dept_data = list(
+            qs.values('department__name').annotate(total=Count('id')).order_by('-total')[:10]
+        )
+        dept_labels = [d['department__name'] or _('None') for d in dept_data]
+        dept_values = [d['total'] for d in dept_data]
+
+        context.update(
+            status_labels=json.dumps(status_labels),
+            status_values=json.dumps(status_values),
+            user_labels=json.dumps(user_labels),
+            user_values=json.dumps(user_values),
+            category_labels=json.dumps(cat_labels),
+            category_values=json.dumps(cat_values),
+            subcategory_labels=json.dumps(subcat_labels),
+            subcategory_values=json.dumps(subcat_values),
+            month_labels=json.dumps(month_labels),
+            month_values=json.dumps(month_values),
+            department_labels=json.dumps(dept_labels),
+            department_values=json.dumps(dept_values),
+            users=User.objects.all(),
+            categories=TaskCategory.objects.all(),
+            subcategories=TaskSubcategory.objects.all(),
+            departments=Department.objects.all(),
+        )
+        return context

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,6 +68,7 @@
                             {% if perms.tasks.view_category %}
                             <li><a href="{% url 'tasks:category_list' %}" class="block px-4 py-2 hover:bg-gray-100">{% trans 'Категории' %}</a></li>
                             {% endif %}
+                            <li><a href="{% url 'dashboards:task_dashboard' %}" class="block px-4 py-2 hover:bg-gray-100">{% trans 'Дашборд' %}</a></li>
                         </ul>
                     </div>
                  </div>

--- a/templates/dashboards/task_dashboard.html
+++ b/templates/dashboards/task_dashboard.html
@@ -1,0 +1,75 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block title %}{% trans 'Дашборд задач' %}{% endblock %}
+
+{% block content %}
+<div class="container mx-auto px-4 py-6">
+  <h1 class="text-2xl font-bold mb-4">{% trans 'Дашборд задач' %}</h1>
+  <form method="get" class="grid grid-cols-1 md:grid-cols-6 gap-4 mb-6">
+    <input type="date" name="start" value="{{ request.GET.start }}" class="border rounded p-2">
+    <input type="date" name="end" value="{{ request.GET.end }}" class="border rounded p-2">
+    <select name="user" class="border rounded p-2">
+      <option value="">{% trans 'Пользователь' %}</option>
+      {% for u in users %}
+      <option value="{{ u.id }}" {% if request.GET.user == u.id|stringformat:'s' %}selected{% endif %}>{{ u.username }}</option>
+      {% endfor %}
+    </select>
+    <select name="category" class="border rounded p-2">
+      <option value="">{% trans 'Категория' %}</option>
+      {% for c in categories %}
+      <option value="{{ c.id }}" {% if request.GET.category == c.id|stringformat:'s' %}selected{% endif %}>{{ c.name }}</option>
+      {% endfor %}
+    </select>
+    <select name="subcategory" class="border rounded p-2">
+      <option value="">{% trans 'Подкатегория' %}</option>
+      {% for sc in subcategories %}
+      <option value="{{ sc.id }}" {% if request.GET.subcategory == sc.id|stringformat:'s' %}selected{% endif %}>{{ sc.name }}</option>
+      {% endfor %}
+    </select>
+    <select name="department" class="border rounded p-2">
+      <option value="">{% trans 'Отдел' %}</option>
+      {% for d in departments %}
+      <option value="{{ d.id }}" {% if request.GET.department == d.id|stringformat:'s' %}selected{% endif %}>{{ d.name }}</option>
+      {% endfor %}
+    </select>
+    <button type="submit" class="bg-blue-600 text-white rounded px-4">{% trans 'Фильтр' %}</button>
+  </form>
+
+  <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div>
+      <canvas id="statusChart"></canvas>
+    </div>
+    <div>
+      <canvas id="userChart"></canvas>
+    </div>
+    <div>
+      <canvas id="categoryChart"></canvas>
+    </div>
+    <div>
+      <canvas id="subCategoryChart"></canvas>
+    </div>
+    <div>
+      <canvas id="monthChart"></canvas>
+    </div>
+    <div>
+      <canvas id="departmentChart"></canvas>
+    </div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script>
+const statusCtx = document.getElementById('statusChart');
+new Chart(statusCtx, {type:'bar',data:{labels:{{ status_labels|safe }},datasets:[{label:'{% trans "Статусы" %}',data:{{ status_values|safe }},backgroundColor:'#3b82f6'}]}});
+const userCtx=document.getElementById('userChart');
+new Chart(userCtx,{type:'bar',data:{labels:{{ user_labels|safe }},datasets:[{label:'{% trans "Пользователи" %}',data:{{ user_values|safe }},backgroundColor:'#10b981'}]}});
+const catCtx=document.getElementById('categoryChart');
+new Chart(catCtx,{type:'bar',data:{labels:{{ category_labels|safe }},datasets:[{label:'{% trans "Категории" %}',data:{{ category_values|safe }},backgroundColor:'#6366f1'}]}});
+const subCtx=document.getElementById('subCategoryChart');
+new Chart(subCtx,{type:'bar',data:{labels:{{ subcategory_labels|safe }},datasets:[{label:'{% trans "Подкатегории" %}',data:{{ subcategory_values|safe }},backgroundColor:'#f97316'}]}});
+const monthCtx=document.getElementById('monthChart');
+new Chart(monthCtx,{type:'line',data:{labels:{{ month_labels|safe }},datasets:[{label:'{% trans "По месяцам" %}',data:{{ month_values|safe }},backgroundColor:'#0ea5e9'}]}});
+const deptCtx=document.getElementById('departmentChart');
+new Chart(deptCtx,{type:'bar',data:{labels:{{ department_labels|safe }},datasets:[{label:'{% trans "Отделы" %}',data:{{ department_values|safe }},backgroundColor:'#d946ef'}]}});
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create new `dashboards` app for reporting
- show task analytics charts with filters
- link dashboard in base navigation
- register new routes and app
- cover dashboard view with tests

## Testing
- `pip install -r requirements.txt`
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_685406e665c0832ebc6e4ef7251d4638