### PR TITLE
Fix admin inline field handling

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -507,9 +507,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (commentTextErrors) commentTextErrors.textContent = ''; if (commentNonFieldErrors) commentNonFieldErrors.textContent = '';
                 commentTextArea.classList.remove('border-red-500');
                 if (!commentText) { if (commentTextErrors) commentTextErrors.textContent = T.commentCannotBeEmpty; commentTextArea.classList.add('border-red-500'); commentTextArea.focus(); return; }
+                const formData = new FormData(commentForm);
                 commentTextArea.disabled = true; commentSubmitBtn.disabled = true; const originalBtnHtml = commentSubmitBtn.innerHTML; commentSubmitBtn.innerHTML = `<i class="fas fa-spinner fa-spin mr-2"></i> ${T.sending}`;
                 try {
-                    const formData = new FormData(commentForm);
                     const response = await window.authenticatedFetch(commentForm.action, { method: 'POST', body: formData, headers: {'Accept': 'application/json'} });
                     let responseData; const contentType = response.headers.get("content-type");
                     if (contentType && contentType.includes("application/json")) responseData = await response.json();


### PR DESCRIPTION
## Summary
- properly disable `assigned_by` field in admin inline
- remove unused custom `save_related` handling
- fix saving of assignment inline and use prefetched roles
- replace bare `except` blocks with safer `except Exception`
- fix comment form to submit text before disabling field

## Testing
- `python manage.py test` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68582b2d1e0c832e8b2a20c81b8998f3