### PR TITLE
Fix blocktrans plural syntax

### DIFF
--- a/templates/includes/subcategory_card.html
+++ b/templates/includes/subcategory_card.html
@@ -13,7 +13,9 @@
     </div>
     <div class="border-t border-gray-200 bg-gray-50 px-4 py-3 sm:px-6 flex justify-between items-center">
         <span class="text-sm text-gray-500">
-            {% blocktrans count=subcategory.tasks.count %}{{ count }} задача{% plural %}{{ count }} задач{% endblocktrans %}
+            {% blocktrans count task_count=subcategory.tasks.count %}
+                {{ task_count }} задача{% plural %}{{ task_count }} задач
+            {% endblocktrans %}
         </span>
         <div class="flex space-x-2">
             <a href="{% url 'tasks:subcategory_update' pk=subcategory.pk %}" class="px-2 py-1 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50" aria-label="{% trans 'Редактировать' %}">


### PR DESCRIPTION
## Summary
- fix blocktrans argument for pluralization

## Testing
- `python manage.py test agents` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_685845b59608832eb4e2be7870f3780e