### PR TITLE
Improve UI buttons and navigation

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -99,3 +99,9 @@ html.no-js #preloader {
 .btn-secondary {
     @apply bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-2 focus:ring-indigo-500;
 }
+.btn-warning {
+    @apply bg-yellow-500 text-white hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-400;
+}
+.btn-danger {
+    @apply bg-red-600 text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,9 +11,7 @@
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="preconnect" href="https://ajax.googleapis.com">
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <!-- Bootswatch Zephyr theme -->
-    <link rel="stylesheet" href="{% static 'vendor/bootswatch/zephyr/bootstrap.min.css' %}">
+    {% comment %} Tailwind CSS is compiled locally {% endcomment %}
     {% tailwind_css %}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
@@ -21,7 +19,6 @@
         crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://unpkg.com/alpinejs@3.14.9/dist/cdn.min.js" defer></script>
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js" defer></script>
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
     <script src="{% static 'js/base_main.js' %}" defer></script>
     <script src="{% static 'js/search.js' %}" defer></script>
@@ -118,9 +115,14 @@
                             {% if perms.auth.view_group %}
                             <li><a href="{% url 'user_profiles:group_list' %}" class="block px-4 py-2 hover:bg-gray-100">{% trans 'Группы' %}</a></li>
                             {% endif %}
-                         </ul>
+                        </ul>
                     </div>
                 </div>
+                {% endif %}
+                {% if perms.room.view_room %}
+                <a href="{% url 'room:rooms' %}" class="px-4 py-2 rounded-lg text-sm font-medium text-gray-900 bg-white border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-2 focus:ring-blue-700 focus:text-blue-700 transition-colors duration-150 inline-flex items-center">
+                    <i class="fas fa-comments mr-2 text-gray-500"></i> {% trans 'Чаты' %}
+                </a>
                 {% endif %}
             </nav>
         </div>
@@ -239,6 +241,11 @@
                 class="flex items-center px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100"><i
                     class="fas fa-project-diagram w-5 mr-3 text-purple-500"></i> {% trans 'Проекты' %}</a>
             {% endif %}
+            {% if perms.room.view_room %}
+            <a href="{% url 'room:rooms' %}"
+                class="flex items-center px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100"><i
+                    class="fas fa-comments w-5 mr-3 text-gray-500"></i> {% trans 'Чаты' %}</a>
+            {% endif %}
             {% if perms.checklists.view_checklisttemplate %}
             <a href="{% url 'checklists:template_list' %}"
                class="flex items-center px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100"><i
@@ -348,7 +355,6 @@
     </div>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/node-uuid/1.4.8/uuid.min.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
     <script src="{% static 'js/uuid.min.js' %}"></script>
 
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>

--- a/templates/tasks/task_form.html
+++ b/templates/tasks/task_form.html
@@ -136,11 +136,11 @@
 
         <div class="flex justify-end items-center space-x-3 pt-8 mt-8 border-t border-gray-200">
             <a href="{% if object and object.pk %}{{ object.get_absolute_url }}{% elif task_instance and task_instance.pk %}{{ task_instance.get_absolute_url }}{% else %}{% url 'tasks:task_list' %}{% endif %}"
-               class="px-5 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 transition-colors shadow-sm">
+               class="btn btn-secondary">
                 {% trans 'Отмена' %}
             </a>
             <button type="submit"
-                    class="px-5 py-2.5 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 transition-colors shadow-md inline-flex items-center">
+                    class="btn btn-primary inline-flex items-center">
                 <i class="fa-solid fa-floppy-disk mr-2 h-4 w-4" aria-hidden="true"></i>
                 {{ form_action_label }}
             </button>

--- a/templates/tasks/task_list.html
+++ b/templates/tasks/task_list.html
@@ -18,12 +18,11 @@
 {% block list_actions %}
 <div class="flex items-center ml-4">
     <div class="inline-flex gap-2">
-        <a href="{{ create_url }}"
-           class="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center">
+        <a href="{{ create_url }}" class="btn btn-primary">
             <i class="fas fa-plus mr-2" aria-hidden="true"></i> {% trans 'Создать задачу' %}
         </a>
         <button type="button" id="toggleViewBtn"
-                class="px-4 py-2 rounded-md text-sm font-medium text-blue-700 bg-white border border-blue-500 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center"
+                class="btn btn-secondary text-blue-700 border-blue-500"
                 aria-pressed="false"
                 data-kanban-text="{% trans 'Канбан' %}" data-list-text="{% trans 'Список' %}">
             <i id="viewIcon" class="fas fa-columns mr-2" aria-hidden="true"></i>
@@ -33,7 +32,7 @@
 
     <div id="column-toggle-dropdown-wrapper" class="relative hidden">
         <button id="dropdownCheckboxButton"
-                class="ml-2 px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center"
+                class="btn btn-primary ml-2"
                 data-bs-toggle="dropdown" type="button">
             <i class="fas fa-eye-slash mr-2" aria-hidden="true"></i> {% trans 'Колонки' %}
         </button>

--- a/templates/users/password_change_form.html
+++ b/templates/users/password_change_form.html
@@ -23,10 +23,10 @@
                 {% csrf_token %}
                 {% crispy form %}
                 <div class="flex justify-end gap-3 mt-6 pt-5 border-t border-gray-200">
-                    <a href="{% url 'user_profiles:profile_view' %}" class="px-5 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 transition-colors shadow-sm">
+                    <a href="{% url 'user_profiles:profile_view' %}" class="btn btn-secondary">
                         {% translate 'Отмена' %}
                     </a>
-                    <button type="submit" class="flex justify-center items-center rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 shadow-md transition active:scale-95 focus:outline-none focus:ring-4 focus:ring-blue-300">
+                    <button type="submit" class="btn btn-primary flex items-center">
                         <i class="fas fa-key mr-2"></i> {% translate 'Сменить пароль' %}
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- unify button utility classes in `main.css`
- switch templates to Tailwind-based buttons
- add chat link in the main navigation
- remove bootstrap theme includes

## Testing
- `python manage.py test agents` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_68585b2bf168832e8e37299eb2c69265