### PR TITLE
Improve UI buttons and navigation

### DIFF
--- a/qrfikr/templates/qrfikr/location_detail.html
+++ b/qrfikr/templates/qrfikr/location_detail.html
@@ -6,6 +6,6 @@
 
 {% block content %}
 <p class="mb-4">{{ object.description }}</p>
-<a href="{{ object.get_feedback_url }}" class="text-blue-600 hover:underline">{% trans 'Leave feedback' %}</a>
+<a href="{{ object.get_feedback_url }}" class="btn btn-primary inline-block">{% trans 'Leave feedback' %}</a>
 
 {% endblock %}

--- a/qrfikr/templates/qrfikr/submit_review.html
+++ b/qrfikr/templates/qrfikr/submit_review.html
@@ -14,7 +14,7 @@
     {% include 'includes/form_field.html' with field=form.photo %}
     {% include 'includes/form_field.html' with field=form.contact_info %}
     <div class="flex justify-end pt-2">
-        <button type="submit" class="px-5 py-2.5 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-700">
+        <button type="submit" class="btn btn-primary">
             {% trans 'Submit' %}
         </button>
     </div>

--- a/qrfikr/templates/qrfikr/thank_you.html
+++ b/qrfikr/templates/qrfikr/thank_you.html
@@ -6,6 +6,6 @@
 {% block content %}
 <p class="text-lg mb-4">{% trans 'Thank you for your feedback!' %}</p>
 <p class="mb-4">{{ qr_link.point.name }}</p>
-<a href="{{ qr_link.get_feedback_url }}" class="text-blue-600 hover:underline">{% trans 'Submit another' %}</a>
+<a href="{{ qr_link.get_feedback_url }}" class="btn btn-primary inline-block">{% trans 'Submit another' %}</a>
 
 {% endblock %}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -99,3 +99,9 @@ html.no-js #preloader {
 .btn-secondary {
     @apply bg-white text-gray-700 border border-gray-300 hover:bg-gray-50 focus:ring-2 focus:ring-indigo-500;
 }
+.btn-warning {
+    @apply bg-yellow-500 text-white hover:bg-yellow-600 focus:ring-2 focus:ring-yellow-400;
+}
+.btn-danger {
+    @apply bg-red-600 text-white hover:bg-red-700 focus:ring-2 focus:ring-red-500;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,9 +11,7 @@
     <link rel="preconnect" href="https://unpkg.com">
     <link rel="preconnect" href="https://cdn.jsdelivr.net">
     <link rel="preconnect" href="https://ajax.googleapis.com">
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-    <!-- Bootswatch Zephyr theme -->
-    <link rel="stylesheet" href="{% static 'vendor/bootswatch/zephyr/bootstrap.min.css' %}">
+    {% comment %} Tailwind CSS is compiled locally {% endcomment %}
     {% tailwind_css %}
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
@@ -21,7 +19,6 @@
         crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://unpkg.com/alpinejs@3.14.9/dist/cdn.min.js" defer></script>
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/flowbite/2.2.1/flowbite.min.js" defer></script>
     <link rel="stylesheet" href="{% static 'css/main.css' %}">
     <script src="{% static 'js/base_main.js' %}" defer></script>
     <script src="{% static 'js/search.js' %}" defer></script>
@@ -118,9 +115,14 @@
                             {% if perms.auth.view_group %}
                             <li><a href="{% url 'user_profiles:group_list' %}" class="block px-4 py-2 hover:bg-gray-100">{% trans 'Группы' %}</a></li>
                             {% endif %}
-                         </ul>
+                        </ul>
                     </div>
                 </div>
+                {% endif %}
+                {% if perms.room.view_room %}
+                <a href="{% url 'room:rooms' %}" class="px-4 py-2 rounded-lg text-sm font-medium text-gray-900 bg-white border border-gray-200 hover:bg-gray-100 hover:text-blue-700 focus:z-10 focus:ring-2 focus:ring-blue-700 focus:text-blue-700 transition-colors duration-150 inline-flex items-center">
+                    <i class="fas fa-comments mr-2 text-gray-500"></i> {% trans 'Чаты' %}
+                </a>
                 {% endif %}
             </nav>
         </div>
@@ -239,6 +241,11 @@
                 class="flex items-center px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100"><i
                     class="fas fa-project-diagram w-5 mr-3 text-purple-500"></i> {% trans 'Проекты' %}</a>
             {% endif %}
+            {% if perms.room.view_room %}
+            <a href="{% url 'room:rooms' %}"
+                class="flex items-center px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100"><i
+                    class="fas fa-comments w-5 mr-3 text-gray-500"></i> {% trans 'Чаты' %}</a>
+            {% endif %}
             {% if perms.checklists.view_checklisttemplate %}
             <a href="{% url 'checklists:template_list' %}"
                class="flex items-center px-3 py-2 rounded-md text-gray-700 hover:bg-gray-100"><i
@@ -348,7 +355,6 @@
     </div>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/node-uuid/1.4.8/uuid.min.js"></script>
 
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
     <script src="{% static 'js/uuid.min.js' %}"></script>
 
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/toastify-js"></script>

--- a/templates/checklists/template_form.html
+++ b/templates/checklists/template_form.html
@@ -71,7 +71,7 @@
                 {% include "includes/formset_item.html" with form=item_formset.empty_form formset=item_formset prefix=item_formset.prefix forloop=None %}
             </div>
             <div class="mt-4">
-                <button type="button" id="add-item-form" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">
+                <button type="button" id="add-item-form" class="btn btn-secondary">
                     <i class="fas fa-plus mr-2"></i> {% trans 'Добавить пункт' %}
                 </button>
             </div>
@@ -79,10 +79,10 @@
         </fieldset>
 
         <div class="flex justify-end items-center space-x-3 pt-6 mt-6 border-t border-gray-200">
-            <a href="{% if object %}{{ object.get_absolute_url }}{% else %}{% url 'checklists:template_list' %}{% endif %}" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">
+            <a href="{% if object %}{{ object.get_absolute_url }}{% else %}{% url 'checklists:template_list' %}{% endif %}" class="btn btn-secondary">
                 {% trans 'Отмена' %}
             </a>
-            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">
+            <button type="submit" class="btn btn-primary">
                 <i class="fa-solid fa-floppy-disk mr-2 h-4 w-4"></i>
                 {% if object %}{% trans "Сохранить изменения" %}{% else %}{% trans "Создать шаблон" %}{% endif %}
             </button>

--- a/templates/hrbot/success.html
+++ b/templates/hrbot/success.html
@@ -5,7 +5,8 @@
     <meta charset="UTF-8">
     <title>{% trans "Успешно" %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="https://cdn.tailwindcss.com"></script>
+    {% comment %} Tailwind CSS compiled locally {% endcomment %}
+    {% tailwind_css %}
     <link rel="shortcut icon" href="{% static 'img/fav.png' %}" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 </head>
@@ -21,7 +22,7 @@
             {% endblock %}
         </p>
         <div class="mt-6">
-            <a href="{% url 'user_profiles:user_list' %}" class="px-5 py-2.5 rounded-md text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm inline-flex items-center">
+            <a href="{% url 'user_profiles:user_list' %}" class="btn btn-primary inline-flex items-center">
                 <i class="fas fa-arrow-left mr-2"></i> {% trans "Вернуться к списку пользователей" %}
             </a>
         </div>

--- a/templates/room/create_room.html
+++ b/templates/room/create_room.html
@@ -86,10 +86,10 @@
             </div>
         </div>
         <div class="flex justify-end items-center space-x-3 pt-6 mt-6 border-t border-gray-200">
-            <a href="{% url 'room:rooms' %}" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">
+            <a href="{% url 'room:rooms' %}" class="btn btn-secondary">
                 {% trans 'Отмена' %}
             </a>
-            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition active:scale-95 shadow-sm inline-flex items-center">
+            <button type="submit" class="btn btn-primary inline-flex items-center">
                 <i class="fas fa-plus mr-2"></i> {% trans 'Создать комнату' %}
             </button>
         </div>

--- a/templates/room/room_form.html
+++ b/templates/room/room_form.html
@@ -78,10 +78,10 @@
             </div>
         </div>
         <div class="flex justify-end items-center space-x-3 pt-6 mt-6 border-t border-gray-200">
-            <a href="{% url 'room:rooms' %}" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">
+            <a href="{% url 'room:rooms' %}" class="btn btn-secondary">
                 {% trans 'Отмена' %}
             </a>
-            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition active:scale-95 shadow-sm inline-flex items-center">
+            <button type="submit" class="btn btn-primary inline-flex items-center">
                 {% if form.instance.pk %}<i class="fas fa-save mr-2"></i> {% trans "Сохранить изменения" %}{% else %}<i class="fas fa-plus mr-2"></i> {% trans "Создать комнату" %}{% endif %}
             </button>
         </div>

--- a/templates/room/room_list.html
+++ b/templates/room/room_list.html
@@ -11,7 +11,7 @@
     </h1>
     {% if perms.room.add_room %} {# Стандартная проверка прав Django #}
     <a href="{% url 'room:create_room' %}"
-       class="px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition active:scale-95 shadow-sm inline-flex items-center">
+       class="btn btn-primary">
         <i class="fas fa-plus mr-2"></i> {% trans 'Создать новую комнату' %}
     </a>
     {% endif %}
@@ -37,7 +37,7 @@
         <p class="text-sm mt-1">{% trans "Вы можете создать новую комнату." %}</p>
         {% if perms.room.add_room %}
         <div class="mt-4">
-            <a href="{% url 'room:create_room' %}" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition active:scale-95 shadow-sm inline-flex items-center">
+            <a href="{% url 'room:create_room' %}" class="btn btn-primary inline-flex items-center">
                 <i class="fas fa-plus mr-2"></i> {% trans 'Создать первую комнату' %}
             </a>
         </div>

--- a/templates/tasks/category_form.html
+++ b/templates/tasks/category_form.html
@@ -42,11 +42,11 @@
          {% endif %}
         <div class="flex justify-end items-center space-x-3 pt-6 mt-6 border-t border-gray-200 ">
             <a href="{% url 'tasks:category_list' %}"
-               class="px-4 py-2 rounded-md text-sm font-medium text-gray-700  bg-white  border border-gray-300  hover:bg-gray-50  focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500  transition active:scale-95 shadow-sm">
+               class="btn btn-secondary">
                 {% trans 'Отмена' %}
             </a>
             <button type="submit"
-                    class="px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500    transition active:scale-95 shadow-sm inline-flex items-center">
+                    class="btn btn-primary inline-flex items-center">
                  <i class="fa-solid fa-floppy-disk mr-2 h-4 w-4" aria-hidden="true"></i>
                  {# Use if tag for the button text #}
                  {% if form.instance.pk %}

--- a/templates/tasks/category_list.html
+++ b/templates/tasks/category_list.html
@@ -12,14 +12,14 @@
 {% block list_actions %}
 <div class="flex items-center ml-4">
     <a href="{% url 'tasks:category_create' %}"
-       class="px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition active:scale-95 shadow-sm inline-flex items-center">
+       class="btn btn-primary">
         <i class="fas fa-folder-plus mr-2" aria-hidden="true"></i> {% trans 'Создать категорию' %}
     </a>
 </div>
 {% endblock %}
 
 {% block list_actions_mobile %}
-<a href="{% url 'tasks:category_create' %}" class="flex-1 px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition active:scale-95 shadow-sm inline-flex items-center justify-center">
+<a href="{% url 'tasks:category_create' %}" class="flex-1 btn btn-primary justify-center">
     <i class="fas fa-folder-plus mr-2" aria-hidden="true"></i> {% trans 'Создать категорию' %}
 </a>
 {% endblock %}

--- a/templates/tasks/subcategory_form.html
+++ b/templates/tasks/subcategory_form.html
@@ -39,10 +39,10 @@
         {% endif %}
         <div class="flex justify-end items-center space-x-3 pt-6 mt-6 border-t border-gray-200">
             <a href="{% url 'tasks:subcategory_list' %}"
-               class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm">
+               class="btn btn-secondary">
                 {% trans 'Отмена' %}
             </a>
-            <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-teal-600 hover:bg-teal-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-teal-500 transition active:scale-95 shadow-sm inline-flex items-center">
+            <button type="submit" class="btn btn-primary inline-flex items-center">
                 <i class="fa-solid fa-floppy-disk mr-2 h-4 w-4" aria-hidden="true"></i>
                 {% if form.instance.pk %}{% trans "Сохранить изменения" %}{% else %}{% trans "Создать подкатегорию" %}{% endif %}
             </button>

--- a/templates/tasks/subcategory_list.html
+++ b/templates/tasks/subcategory_list.html
@@ -11,9 +11,8 @@
 
 {% block list_actions %}
     <a href="{% url 'tasks:subcategory_create' %}"
-        class="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center ml-3"
-        aria-label="{% trans 'Создать новую подкатегорию' %}"
-    >
+        class="btn btn-primary ml-3"
+        aria-label="{% trans 'Создать новую подкатегорию' %}">
         <i class="fas fa-plus mr-2" aria-hidden="true"></i> {% trans 'Создать подкатегорию' %}
     </a>
 {% endblock %}

--- a/templates/tasks/task_edit_form.html
+++ b/templates/tasks/task_edit_form.html
@@ -4,7 +4,7 @@
     {% csrf_token %}
     {{ task_form|crispy }}
     <div class="flex justify-end space-x-2 mt-4 pt-4 border-t border-gray-200">
-        <button type="button" id="cancel-edit-modal-btn" class="px-4 py-2 rounded-md text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 transition active:scale-95 shadow-sm" onclick="closeEditModal()">{% trans "Отмена" %}</button>
-        <button type="submit" class="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm">{% trans "Сохранить изменения" %}</button>
+        <button type="button" id="cancel-edit-modal-btn" class="btn btn-secondary" onclick="closeEditModal()">{% trans "Отмена" %}</button>
+        <button type="submit" class="btn btn-primary">{% trans "Сохранить изменения" %}</button>
     </div>
 </form>

--- a/templates/tasks/task_form.html
+++ b/templates/tasks/task_form.html
@@ -136,11 +136,11 @@
 
         <div class="flex justify-end items-center space-x-3 pt-8 mt-8 border-t border-gray-200">
             <a href="{% if object and object.pk %}{{ object.get_absolute_url }}{% elif task_instance and task_instance.pk %}{{ task_instance.get_absolute_url }}{% else %}{% url 'tasks:task_list' %}{% endif %}"
-               class="px-5 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 transition-colors shadow-sm">
+               class="btn btn-secondary">
                 {% trans 'Отмена' %}
             </a>
             <button type="submit"
-                    class="px-5 py-2.5 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 focus:outline-none focus:ring-4 focus:ring-blue-300 transition-colors shadow-md inline-flex items-center">
+                    class="btn btn-primary inline-flex items-center">
                 <i class="fa-solid fa-floppy-disk mr-2 h-4 w-4" aria-hidden="true"></i>
                 {{ form_action_label }}
             </button>

--- a/templates/tasks/task_list.html
+++ b/templates/tasks/task_list.html
@@ -18,12 +18,11 @@
 {% block list_actions %}
 <div class="flex items-center ml-4">
     <div class="inline-flex gap-2">
-        <a href="{{ create_url }}"
-           class="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center">
+        <a href="{{ create_url }}" class="btn btn-primary">
             <i class="fas fa-plus mr-2" aria-hidden="true"></i> {% trans 'Создать задачу' %}
         </a>
         <button type="button" id="toggleViewBtn"
-                class="px-4 py-2 rounded-md text-sm font-medium text-blue-700 bg-white border border-blue-500 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center"
+                class="btn btn-secondary text-blue-700 border-blue-500"
                 aria-pressed="false"
                 data-kanban-text="{% trans 'Канбан' %}" data-list-text="{% trans 'Список' %}">
             <i id="viewIcon" class="fas fa-columns mr-2" aria-hidden="true"></i>
@@ -33,7 +32,7 @@
 
     <div id="column-toggle-dropdown-wrapper" class="relative hidden">
         <button id="dropdownCheckboxButton"
-                class="ml-2 px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center"
+                class="btn btn-primary ml-2"
                 data-bs-toggle="dropdown" type="button">
             <i class="fas fa-eye-slash mr-2" aria-hidden="true"></i> {% trans 'Колонки' %}
         </button>
@@ -68,11 +67,11 @@
 
 {% block list_actions_mobile %}
 <a href="{{ create_url }}"
-   class="flex-1 px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center justify-center">
+   class="flex-1 btn btn-primary justify-center">
     <i class="fas fa-plus mr-2" aria-hidden="true"></i> {% trans 'Создать задачу' %}
 </a>
 <button type="button" id="toggleViewBtnMobile"
-        class="flex-1 px-4 py-2 rounded-md text-sm font-medium text-blue-700 bg-white border border-blue-500 hover:bg-blue-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition active:scale-95 shadow-sm inline-flex items-center justify-center"
+        class="flex-1 btn btn-secondary text-blue-700 border-blue-500 justify-center"
         aria-pressed="false"
         data-kanban-text="{% trans 'Канбан' %}" data-list-text="{% trans 'Список' %}">
     <i id="viewIconMobile" class="fas fa-columns mr-2" aria-hidden="true"></i>

--- a/templates/users/login.html
+++ b/templates/users/login.html
@@ -7,7 +7,7 @@
     <meta name="description" content="{% translate 'Sphinx - Вход в систему' %}">
     <link rel="shortcut icon" href="{% static 'img/fav.png' %}" type="image/x-icon">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet" crossorigin="anonymous" />
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    {% comment %} Tailwind CSS compiled locally {% endcomment %}
     {% tailwind_css %}
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css">
     <script src="https://cdn.jsdelivr.net/npm/toastify-js" defer></script>
@@ -79,7 +79,7 @@
 
             <div>
                 <button type="submit" id="submit-btn"
-                    class="w-full flex justify-center items-center gap-2 py-2.5 px-4 bg-blue-600 text-white text-sm font-medium rounded-md hover:bg-blue-700 transition">
+                    class="btn btn-primary w-full justify-center gap-2">
                     <svg id="spinner" class="hidden animate-spin h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
                         <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>

--- a/templates/users/password_change_form.html
+++ b/templates/users/password_change_form.html
@@ -23,10 +23,10 @@
                 {% csrf_token %}
                 {% crispy form %}
                 <div class="flex justify-end gap-3 mt-6 pt-5 border-t border-gray-200">
-                    <a href="{% url 'user_profiles:profile_view' %}" class="px-5 py-2.5 rounded-lg text-sm font-medium text-gray-700 bg-white border border-gray-300 hover:bg-gray-100 focus:outline-none focus:ring-4 focus:ring-gray-200 transition-colors shadow-sm">
+                    <a href="{% url 'user_profiles:profile_view' %}" class="btn btn-secondary">
                         {% translate 'Отмена' %}
                     </a>
-                    <button type="submit" class="flex justify-center items-center rounded-lg bg-blue-600 px-6 py-2.5 text-sm font-medium text-white hover:bg-blue-700 shadow-md transition active:scale-95 focus:outline-none focus:ring-4 focus:ring-blue-300">
+                    <button type="submit" class="btn btn-primary flex items-center">
                         <i class="fas fa-key mr-2"></i> {% translate 'Сменить пароль' %}
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- unify button utility classes in `main.css`
- switch templates to Tailwind-based buttons
- add chat link in the main navigation
- remove bootstrap theme includes
- apply unified buttons in more templates

## Testing
- `python manage.py test agents` *(fails: ModuleNotFoundError: No module named 'agents')*

------
https://chatgpt.com/codex/tasks/task_e_68585b2bf168832e8e37299eb2c69265