### PR TITLE
Fix login url name

### DIFF
--- a/user_profiles/urls.py
+++ b/user_profiles/urls.py
@@ -14,7 +14,7 @@ router.register(r'jobtitles', views.JobTitleViewSet, basename='jobtitle-api')
 
 urlpatterns = [
     path('', views.base_login_view, name='base_login'),
-    path('login/', views.user_login_redirect, name='login_redirect'),
+    path('login/', views.user_login_redirect, name='login'),
     path('logout/', views.user_logout_view, name='logout'),
 
     path('api/v1/', include(router.urls)),


### PR DESCRIPTION
## Summary
- fix login URL naming so Django can reverse it

## Testing
- `python manage.py test agents` *(fails: ModuleNotFoundError: No module named 'encrypted_model_fields')*

------
https://chatgpt.com/codex/tasks/task_e_68585efd82cc832eaf0529295b922d59